### PR TITLE
docs(workflows): consolidate to three phases (plan → build → verify)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Update Requirements (per task)
 
 One LLM executes work by following process markdowns in `agents/workflows/`.
 
-- Phases: planner → retriever → architect → implementer → reviewer → tester → documenter
+- Phases: plan → build → verify
 - Each process file defines checklists, inputs/outputs, and quality gates.
 - The LLM loads the process .md (+ linked partials), executes the current phase, writes artifacts, updates phase state, advances when gates pass, and logs a short Reflexion to the Memory Bank.
 - External tools: prefer GitHub MCP for git workflows.

--- a/agents/memory-bank.md
+++ b/agents/memory-bank.md
@@ -1,7 +1,7 @@
 ---
 memory_bank: v1
 generated_at: 2025-09-11
-repo_git_sha: 4d16b6e01ced53b45105d0d6d89baf9665b319de
+repo_git_sha: 001c59c10aa71f2d2e8bb3728800def7f41df740
 ---
 
 Memory Bank

--- a/agents/memory-bank/active.context.md
+++ b/agents/memory-bank/active.context.md
@@ -47,3 +47,6 @@ Reflexion
 - What happened (2025-09-11, ops): Post-dependency update verification: ran lint (green), full builds via Turbo (green), and attempted tests. `turbo run test` failed due to missing test scripts in some workspaces.
 - What worked: Build pipeline validated SSR/client apps and packages; environment injection and postbuild steps executed successfully.
 - Next time: Make root `test` resilient (e.g., use `npm -ws run test --if-present`) or add no-op `test` scripts to all workspaces to avoid Turbo missing-task errors.
+- What happened (2025-09-11, workflows): Consolidated workflows to 3 phases (plan → build → verify); updated default, template, overview; recorded ADR-0004.
+- What worked: Simpler handoffs and fewer transitions while preserving quality gates and Memory Bank updates.
+- Next time: Monitor usage and, if needed, add optional sub-checklists per task type without increasing phase count.

--- a/agents/memory-bank/decisions/ADR-0004-consolidate-workflows-to-three-phases.md
+++ b/agents/memory-bank/decisions/ADR-0004-consolidate-workflows-to-three-phases.md
@@ -1,0 +1,21 @@
+---
+last_reviewed: 2025-09-11
+stage: accepted
+---
+
+# ADR-0004: Consolidate Workflows to Three Phases
+
+Status: Accepted
+Context:
+
+- The existing default and template workflows included seven phases (planner, retriever, architect, implementer, reviewer, tester, documenter).
+- These phases created overhead and duplication between adjacent steps (planning/design/retrieval and review/test/doc).
+- Streamlining improves agent velocity while preserving quality gates and Memory Bank discipline.
+  Decision:
+- Collapse the workflow into three phases: plan → build → verify.
+- Update `agents/workflows.md`, `agents/workflows/default.workflow.md`, and `agents/workflows/templates/pattern.workflow.template.md` to reflect the new structure.
+- Keep global prompts (retrieval policy, commit approvals, formatting habits) intact.
+  Consequences (Positive/Negative):
+- Positive: Simpler handoffs, fewer state transitions, clearer milestones; still enforces acceptance criteria, testing, and memory updates.
+- Negative: Less granularity in phase-specific reporting; requires updating references in docs and habits.
+  Related: `agents/workflows.md`, `agents/workflows/default.workflow.md`, `agents/workflows/templates/pattern.workflow.template.md`, `AGENTS.md`

--- a/agents/memory-bank/progress.log.md
+++ b/agents/memory-bank/progress.log.md
@@ -16,3 +16,4 @@ stage: implementation
 - 2025-09-11: Moved default Layer management to node-server; deleted backend-core `defaultLayer.ts`; `generateRequestHandler` now assumes fully-provided effects; handlers wrap with `Effect.provide(AppLayer)`; added ADR-0003 (Proposed).
 - 2025-09-11: Added root script `format:markdown` using Prettier (CommonMark) to format `agents/**/*.md`; wired via prelint hooks so it runs with `lint`/`lint:fix`; updated default workflow and docs accordingly.
 - 2025-09-11: Ops check after dependency updates — lint passed, Turbo builds for apps/packages passed, tests via `turbo run test` surfaced missing-task errors for workspaces without `test` scripts; recommended making root test resilient or adding no-op tests.
+- 2025-09-11: Consolidated workflows to three phases (plan → build → verify); updated default workflow, pattern template, and overview; added ADR-0004.

--- a/agents/workflows.md
+++ b/agents/workflows.md
@@ -3,7 +3,7 @@ Workflows
 It is very important you strictly follow the agent workflows.
 
 - Default workflow: `agents/workflows/default.workflow.md`
-- Purpose: drive multi-phase execution (planner → retriever → architect → implementer → reviewer → tester → documenter) with explicit inputs/outputs and gates.
+- Purpose: drive three-phase execution (plan → build → verify) with explicit inputs/outputs and gates.
 
 Usage
 

--- a/agents/workflows/templates/pattern.workflow.template.md
+++ b/agents/workflows/templates/pattern.workflow.template.md
@@ -8,75 +8,45 @@ Intent
 
 State
 
-- current_phase: planner
+- current_phase: plan
 - last_actor: <set by agent>
 - derived_from_pattern: <PAT-YYYYMMDD-slug>
 
 Global Prompts
 
-- Follow the same phase structure as default; customize checklists to the pattern’s steps.
+- Follow the same three-phase structure as default; customize checklists to the pattern’s steps.
 - Keep unrelated changes out; update Memory Bank as needed.
 
-Phase: planner
+Phase: plan
 
-- Goal: Frame when to apply this pattern.
+- Goal: Frame applicability, gather context, and tailor the approach.
 - Inputs: Pattern entry; relevant context files.
 - Checklist:
   - Identify applicability and success criteria for pattern use.
   - Note constraints and risks.
-- Outputs: Scope and criteria for using this workflow.
-- Next: retriever
+  - Map impacted components/interfaces specific to this pattern.
+  - Adapt the pattern steps for the task; consider perf/security implications.
+- Outputs: Scope and criteria; tailored plan for this pattern.
+- Next: build
 
-Phase: retriever
+Phase: build
 
-- Goal: Gather context specific to this pattern.
-- Inputs: Pattern Steps and Signals; tech/product context.
-- Checklist:
-  - Map impacted components/interfaces for this pattern.
-- Outputs: Focused context.
-- Next: architect
-
-Phase: architect
-
-- Goal: Adapt the pattern steps to current task.
-- Checklist:
-  - Validate the steps; adjust for constraints.
-  - Consider performance/security implications.
-- Outputs: Tailored plan.
-- Next: implementer
-
-Phase: implementer
-
-- Goal: Execute the pattern steps minimally.
+- Goal: Execute the tailored pattern steps minimally.
 - Checklist:
   - Implement scoped changes according to the pattern.
   - Keep diffs minimal and consistent with repo style.
 - Outputs: Code changes.
-- Next: reviewer
+- Next: verify
 
-Phase: reviewer
+Phase: verify
 
-- Goal: Ensure clarity and minimalism.
+- Goal: Ensure clarity, validate behavior, and update memory.
 - Checklist:
   - Self-review diffs against pattern intent and criteria.
-- Outputs: Fixups; notes.
-- Next: tester
-
-Phase: tester
-
-- Goal: Validate behavior and edge cases.
-- Checklist:
-  - Run targeted tests; validate signals from the pattern.
-- Outputs: Test results.
-- Next: documenter
-
-Phase: documenter
-
-- Goal: Update docs and memory.
-- Checklist:
+  - Run targeted tests; validate pattern signals and edge cases.
   - Record outcomes; update `agents/memory-bank` as needed.
   - If the workflow template evolved, capture those changes here.
-- Outputs: Updated docs; notes.
+- Outputs: Fixups; test results; updated docs/notes.
 - Next: done
 
 End


### PR DESCRIPTION
Update default workflow to plan → build → verify\nAlign pattern template and workflows overview\nUpdate AGENTS guide to three-phase model\nAdd ADR-0004 documenting the change\nUpdate Memory Bank stamps, Reflexion, and progress log\nRun markdown formatting and memory validate/drift checks\nRefs: agents/workflows.md, agents/workflows/default.workflow.md, agents/workflows/templates/pattern.workflow.template.md, AGENTS.md, agents/memory-bank/*