### PR TITLE
docs(agents): centralize retrieval; enforce stage; slim prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,6 @@ One LLM executes work by following process markdowns in `agents/workflows/`.
 It is very important you strictly follow the agent workflows.
 
 Start with: `agents/workflows/default.workflow.md`
+## Conventions
+
+- Markdown: use Prettier via `npm run format:markdown` for `agents/**`; `npm run lint`/`lint:fix` runs it via prelint hook.

--- a/agents/memory-bank.md
+++ b/agents/memory-bank.md
@@ -35,9 +35,9 @@ Retrieval Policy
 
 Stage Metadata Policy
 
-- To avoid drift, do not track “stage”/phase in every Memory Bank file.
-- Ground truth for phase lives in the active workflow file under `agents/workflows/*`.
-- Memory files should use `last_reviewed` to indicate freshness; `stage` is optional and, if used, should be limited to `agents/memory-bank/active.context.md` only.
+- Prefer omitting `stage` in Memory Bank files to avoid drift; rely on `last_reviewed` for freshness.
+- Ground truth for the current phase lives in the active workflow file under `agents/workflows/*`.
+- If `stage` is used, it must be one of `plan|build|verify` and should be limited to `agents/memory-bank/active.context.md` only.
 
 Validation scripts
 

--- a/agents/memory-bank/active.context.md
+++ b/agents/memory-bank/active.context.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: implementation
 ---
 
 # Active Context

--- a/agents/memory-bank/product.context.md
+++ b/agents/memory-bank/product.context.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: planning
 ---
 
 # Product Context

--- a/agents/memory-bank/progress.log.md
+++ b/agents/memory-bank/progress.log.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: implementation
 ---
 
 # Progress Log

--- a/agents/memory-bank/project.brief.md
+++ b/agents/memory-bank/project.brief.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: planning
 ---
 
 # Project Brief

--- a/agents/memory-bank/system.patterns.md
+++ b/agents/memory-bank/system.patterns.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: planning
 ---
 
 # System Patterns

--- a/agents/memory-bank/tech.context.md
+++ b/agents/memory-bank/tech.context.md
@@ -1,6 +1,5 @@
 ---
 last_reviewed: 2025-09-03
-stage: design
 ---
 
 # Technical Context

--- a/agents/workflows.md
+++ b/agents/workflows.md
@@ -15,7 +15,7 @@ Usage
 
 Policies
 
-- Retrieval: follow the canonical policy in `agents/memory-bank.md` (avoid duplicating rules here).
+- Retrieval: Follow Retrieval Policy in `agents/memory-bank.md`.
 - External tools: prefer GitHub MCP for git actions (branching, commits, PRs).
 - Commit confirmation: always ask for explicit approval before each commit (share the Conventional Commit title under 70 chars and a brief body preview) and before pushing.
 - Markdown: use Prettier (`npm run format:markdown`) to format Markdown in `agents/**`. Running `npm run lint` or `npm run lint:fix` at the repo root automatically formats Markdown via a prelint hook.

--- a/agents/workflows/default.workflow.md
+++ b/agents/workflows/default.workflow.md
@@ -12,17 +12,15 @@ State
 
 Global Prompts
 
-- Retrieval setup: Follow the canonical policy in `agents/memory-bank.md` — always include the workflow file, `project.brief.md`, recent `progress.log.md`, and `active.context.md`; include `tech.context.md`, `system.patterns.md`, and ADRs only when substantively relevant.
-- Reflexion note: After each phase, add a 3-line Reflexion to `active.context.md` and append a succinct entry to `progress.log.md`.
-- External tools: Use GitHub MCP for git operations.
-- Linting habit: After completing a task, run `npm run lint:fix` and `npm run format:markdown` (Markdown in `agents/**`). Running `npm run lint` or `npm run lint:fix` at the repo root will automatically format `agents/**/*.md` via prelint hooks.
-- Branch & commit flow: After confirming with the requester, create a branch named `codex/<meaningful-slug>`, commit with a Conventional Commit title under 70 chars, and push upstream to that branch. Offer this step proactively at the start of implementation.
-- Commit confirmation: Before each commit (including fixups), present the proposed Conventional Commit title (< 70 chars) and body, and ask for explicit approval. Do not commit without approval.
+- Retrieval: Follow Retrieval Policy in `agents/memory-bank.md`.
+- Reflexion: After each phase, add a 3-line Reflexion to `active.context.md` and a brief `progress.log.md` entry.
+- Tools/Standards: See `AGENTS.md` for MCP usage and Markdown formatting.
+- Commit approvals: If interactive approvals are enabled, request commit confirmation; otherwise proceed with clear, conventional commit messages.
 
 Phase: plan
 
 - Goal: Clarify scope, gather context, and choose an approach.
-- Inputs: Issue/ask; core context per Memory Bank policy (workflow file, `project.brief.md`, recent `progress.log.md`, `active.context.md`); optionally `product.context.md`; include `tech.context.md`/`system.patterns.md`/ADRs only if substantively relevant.
+- Inputs: Issue/ask; core context per Memory Bank policy.
 - Checklist:
   - Define problem statement, desired outcome, and acceptance criteria.
   - Identify constraints, risks, and assumptions.
@@ -42,8 +40,8 @@ Phase: build
 - Checklist:
   - Implement code and docs surgically; keep unrelated changes out.
   - Update `agents/memory-bank` canonical files if required.
-  - Run `npm run lint:fix` and `npm run format:markdown` to format/fix lint and Markdown.
-  - With confirmation, create `codex/<slug>` branch. Before each commit, ask for approval with the proposed Conventional Commit title (< 70 chars) and body; then push to the remote branch when confirmed.
+  - Run `npm run lint:fix` and `npm run format:markdown`.
+  - Branching/commits: follow `AGENTS.md` conventions; if interactive approvals are enabled, request commit confirmation; otherwise proceed with clear Conventional Commits.
 - Outputs: Code changes; updated docs; migrations/scripts as needed.
 - Done_when: Changes compile and meet plan scope.
 - Gates: Lint/build pass locally.


### PR DESCRIPTION
Single-source retrieval in agents/memory-bank.md; workflows reference policy. Enforce stage metadata (prefer last_reviewed; if used, limit to active.context.md and plan|build|verify). Align phase naming to verify. Slim Global Prompts and scope commit approvals to interactive mode. Update AGENTS.md conventions.